### PR TITLE
Use rlwrap for history saving and arrow keys

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,6 +18,11 @@ git clone https://github.com/aeternity/aerepl.git
 #+END_SRC
 
 Build the project:
+
+This project depends on `rlwrap` to save input history and make the arrow keys work as expected
+inside the repl, but it is still possible to use `aerepl` without `rlwrap` by running
+`./aerepl.escript` instead of `./aerepl`.
+
 #+BEGIN_SRC
 cd aerepl
 make

--- a/aerepl
+++ b/aerepl
@@ -1,13 +1,3 @@
-#!/usr/bin/env escript
-%% -*- erlang -*-
-%%! -smp enable -setcookie aerepl_cookie -mnesia debug verbose
--mode(compile).
+#!/bin/bash
 
-main(_) ->
-  code:add_pathz(filename:join
-                  ( filename:dirname(escript:script_name())
-                  , "_build/prod/lib/aerepl/ebin/")),
-  % dont judge me
-  Name = list_to_atom(lists:filter(fun(X) -> (X >= $0) and ($9 >= X) end, lists:flatten(io_lib:format("~p", [make_ref()])))),
-  net_kernel:start([Name, shortnames]),
-  aere_cli:run().
+rlwrap ./aerepl.escript

--- a/aerepl.escript
+++ b/aerepl.escript
@@ -1,0 +1,13 @@
+#!/usr/bin/env escript
+%% -*- erlang -*-
+%%! -smp enable -setcookie aerepl_cookie -mnesia debug verbose
+-mode(compile).
+
+main(_) ->
+  code:add_pathz(filename:join
+                  ( filename:dirname(escript:script_name())
+                  , "_build/prod/lib/aerepl/ebin/")),
+  % dont judge me
+  Name = list_to_atom(lists:filter(fun(X) -> (X >= $0) and ($9 >= X) end, lists:flatten(io_lib:format("~p", [make_ref()])))),
+  net_kernel:start([Name, shortnames]),
+  aere_cli:run().


### PR DESCRIPTION
After doing some research, `rlwrap` turned out to be the easiest way to support history and handle arrow keys properly.

I have looked into using the library https://github.com/mazenharake/cecho which uses `ncurses`, but it will take a lot longer to implement the repl properly using this library, and the library is not a complete port of ncurses, so more work on the library might also be needed to make things work.

Unlike `ncurses` which is a dependency for the erlang shell, `rlwrap` needs to be installed separately before using it in the project, but `aerepl` can also run without it as mentioned in the docs (but it won't support history and arrow keys).

Fixes: #23 