### PR TITLE
Push rendering of results away from the logic 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.2.0] - 2023.12.19
+
+### Added
+- Option to return rendered results
+- Option to return raw erlang values for successful calls to the gen server
+- Several options to configure printing format
+### Changed
+- Themed rendering now returns bytestrings
+- `print` is renamed to `lookup`
+- `aere_repl` more often returns a tuple `{Result, repl_state()}`
+- CLI uses REPL supervisor directly
+### Removed
+- In-repl functions
+
+
 ## [3.1.1] - 2023.12.10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,20 +25,20 @@ Libraries:
 
 Clone the repo:
 
-```
+```bash
 git clone https://github.com/aeternity/aerepl.git
 ```
 
 Set up the environment. Make sure Erlang 25 is used.
 
-```
+```bash
 export ERLANG_ROCKSDB_OPTS="-DWITH_SYSTEM_ROCKSDB=ON -DWITH_LZ4=ON -DWITH_SNAPPY=ON -DWITH_BZ2=ON -DWITH_ZSTD=ON"
 export CXXFLAGS="-Wno-error=shadow -Wno-deprecated-copy -Wno-redundant-move -Wno-pessimizing-move"
 ```
 
 Build the project (the `make` step may need to be executed twice, see [this issue](https://github.com/aeternity/aerepl/issues/67)):
 
-```
+```bash
 cd aerepl
 make
 ```
@@ -206,17 +206,24 @@ AESO> :set print_unit true
 
 Currently the supported options are:
 
-| Option         | Arguments          | Description                                                         |
-|----------------|--------------------|:--------------------------------------------------------------------|
-| `display_gas`  | `true/false`       | If `true`, REPL will print gas used for evaluating each expression. |
-|----------------|--------------------|:--------------------------------------------------------------------|
-| `call_gas`     | non-neg int        | Determines the amount of gas to be supplied to each query.          |
-|----------------|--------------------|:--------------------------------------------------------------------|
-| `call_value`   | non-neg int        | Sets the `value`, the amount of tokens supplied with the query.     |
-|----------------|--------------------|:--------------------------------------------------------------------|
-| `print_format` | `sophia/fate/json` | Determines the syntax used to display values.                       |
-|----------------|--------------------|:--------------------------------------------------------------------|
-| `print_unit`   | `true/false`       | Whether to display unit (`()`).                                     |
+| Option          | Arguments          | Description                                                         |
+|-----------------|--------------------|:--------------------------------------------------------------------|
+| `display_gas`   | `true/false`       | If `true`, REPL will print gas used for evaluating each expression. |
+|-----------------|--------------------|:--------------------------------------------------------------------|
+| `call_gas`      | non-neg int        | Determines the amount of gas to be supplied to each query.          |
+|-----------------|--------------------|:--------------------------------------------------------------------|
+| `call_value`    | non-neg int        | Sets the `value`, the amount of tokens supplied with the query.     |
+|-----------------|--------------------|:--------------------------------------------------------------------|
+| `print_format`  | `sophia/fate/json` | Determines the syntax used to display values.                       |
+|-----------------|--------------------|:--------------------------------------------------------------------|
+| `print_unit`    | `true/false`       | Whether to display unit (`()`).                                     |
+|-----------------|--------------------|:--------------------------------------------------------------------|
+| `print_type`    | `true/false`       | Whether to display the type after each eval.                        |
+|-----------------|--------------------|:--------------------------------------------------------------------|
+| `loc_backwards` | non-neg int        | Number of previous lines to be displayed when using `location`.     |
+|-----------------|--------------------|:--------------------------------------------------------------------|
+| `loc_forwards`  | non-neg int        | Number of further lines to be displayed when using `location`.      |
+
 
 # Output format
 
@@ -335,7 +342,7 @@ the following fields:
 
 ## Cast
 
-- `{update_filesystem_cache, #{string() => bytes()}}` --- updates REPL's
+- `{update_filesystem_cache, #{string() => binary()}}` --- updates REPL's
   perception of the file system to the provided map. If this is set, all include
   and file load instructions will ignore system's file system, and will use this
   map instead.

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ the following fields:
   configuration (see `{help, "set"}` for more details)
 - `help` --- lists all available commands
 - `{help, string()}` --- returns the help text for the given command
-- `{print, atom()}` --- prints information about REPL's state or configuration
+- `{lookup, atom()}` --- prints information about REPL's state or configuration
 - `{disas, string()}` --- parses a reference to a function and prints its FATE
   code
 - `{break, FileName :: string(), Line :: integer()}` --- adds a breakpoint
@@ -327,6 +327,9 @@ the following fields:
 - `stepout` --- resumes execution until the next breakpoint or current function
   return
 - `location` --- returns in-code location of current execution
+- `{print_var}` --- returns in-code location of current execution
+- `print_vars` --- returns values of all variables in scope
+- `stacktrace` --- returns the current stacktrace
 - `banner` --- returns an ASCII "banner" presenting the REPL's logo and various
   version information
 

--- a/README.md
+++ b/README.md
@@ -306,6 +306,9 @@ the following fields:
   locally defined functions, variables and types are pruned.
 - `{eval, string()}` --- parses the expression and evaluates it in the session
   context
+- `{load, list(string())}` --- Loads files from the file system. Includes the
+  first one in the list.
+- `reload` --- Reloads the currently loaded files.
 - `{set, Option :: atom(), Value :: list(term())}` --- changes REPL's
   configuration (see `{help, "set"}` for more details)
 - `help` --- lists all available commands

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ the following fields:
 - `stepout` --- resumes execution until the next breakpoint or current function
   return
 - `location` --- returns in-code location of current execution
-- `{print_var}` --- returns in-code location of current execution
+- `{print_var, string()}` --- returns in-code location of where the variable was introduced
 - `print_vars` --- returns values of all variables in scope
 - `stacktrace` --- returns the current stacktrace
 - `banner` --- returns an ASCII "banner" presenting the REPL's logo and various

--- a/aerepl
+++ b/aerepl
@@ -13,7 +13,7 @@ load_paths() ->
 
 main(_Args) ->
     load_paths(),
-    aere_gen_server:start([{options, #{return_mode => format}}]),
+    aere_gen_server:start([{options, #{return_mode => render}}]),
     start().
 
 start() ->
@@ -25,12 +25,12 @@ loop() ->
     Input = get_input(),
     try aere_gen_server:input(Input) of
         {ok, Msg} ->
-            print_msg(aere_gen_server:render(Msg)),
+            print_msg(Msg),
             loop();
         {error, Err} ->
-            print_msg(aere_gen_server:render(Err)),
+            print_msg(Err),
             loop();
-        no_output ->
+        ok ->
             loop();
         finish ->
             ok

--- a/aerepl
+++ b/aerepl
@@ -51,7 +51,7 @@ print_msg(Msg) ->
 get_input() ->
     Prompt = aere_gen_server:prompt(),
     Line =
-        case io:get_line(Prompt ++ "> ") of
+        case io:get_line(binary:bin_to_list(Prompt) ++ "> ") of
             eof          -> ":quit"; % that's dirty
             {error, Err} -> exit(Err);
             Data         -> Data

--- a/aerepl
+++ b/aerepl
@@ -13,34 +13,35 @@ load_paths() ->
 
 main(_Args) ->
     load_paths(),
-    aere_gen_server:start([{options, #{return_mode => render}}]),
+    {ok, _Sup} = aere_supervisor:start_link([{options, #{return_mode => render}}]),
     start().
 
 start() ->
     Banner = aere_gen_server:banner(),
-    io:format(Banner ++ "\n\n"),
+    io:format("~s\n\n", [Banner]),
     loop().
 
 loop() ->
     Input = get_input(),
     try aere_gen_server:input(Input) of
+        {ok, finish} ->
+            finish;
         {ok, Msg} ->
             print_msg(Msg),
             loop();
         {error, Err} ->
             print_msg(Err),
-            loop();
-        ok ->
-            loop();
-        finish ->
-            ok
+            loop()
     catch
         _:E:Stack ->
             print_msg(aere_theme:render(aere_msg:internal(E, Stack))),
             loop()
     end.
 
-print_msg("") -> ok;
+print_msg(ok) -> ok;
+print_msg(<<"">>) -> ok;
+print_msg({error, Msg}) ->
+    io:format("~s\n", [Msg]);
 print_msg(Msg) ->
     io:format("~s\n", [Msg]).
 

--- a/aerepl
+++ b/aerepl
@@ -13,7 +13,7 @@ load_paths() ->
 
 main(_Args) ->
     load_paths(),
-    application:ensure_all_started(aerepl),
+    aere_gen_server:start([{options, #{return_mode => format}}]),
     start().
 
 start() ->

--- a/rebar.config
+++ b/rebar.config
@@ -61,19 +61,7 @@
                             {include_erts, true}]}]}
            ]}.
 
-{dialyzer, [ {plt_extra_apps,
-              [
-               %% aesophia
-               %%               , aeserialization
-               %%               , aebytecode
-              %% , "_build/default/lib/aefate/ebin"
-              %% , "node/apps/aecontract"
-              %% , "node/apps/aecore"
-              %% , "node/apps/aetx"
-              ]
+{dialyzer, [ {plt_extra_apps, []
              },
-             {add_pathsa,
-              [ "_build/default/lib/aefate/ebin"
-              ]
-             }
+             {add_pathsa, []}
            ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -31,7 +31,7 @@
   [{add, aebytecode, [{erl_opts, [{d, 'EQC'}]}]
 }]}.
 
-{relx, [{release, {aerepl, "3.1.1"},
+{relx, [{release, {aerepl, "3.2.0"},
          [aerepl, {aechannel, load}, {aecore, load}, {aeutils, load}, {mnesia, load}, sasl]},
         {lib_dirs, ["node/_build/dev1/rel/aeternity/lib/", "_build/prod/lib/"]},
         {dev_mode, true},

--- a/rebar.config
+++ b/rebar.config
@@ -33,7 +33,7 @@
 
 {relx, [{release, {aerepl, "3.1.1"},
          [aerepl, {aechannel, load}, {aecore, load}, {aeutils, load}, {mnesia, load}, sasl]},
-        {lib_dirs, ["node/_build/dev1/rel/aeternity/lib", "_build/prod/lib/"]},
+        {lib_dirs, ["node/_build/dev1/rel/aeternity/lib/", "_build/prod/lib/"]},
         {dev_mode, true},
         {vm_args, "config/vm.args"},
         {sys_config, "config/sys.config"},
@@ -59,4 +59,17 @@
 
 {profiles, [{prod, [{relx, [{dev_mode, false},
                             {include_erts, true}]}]}
+           ]}.
+
+{dialyzer, [ {plt_extra_apps,
+              [
+               %% aesophia
+               %%               , aeserialization
+               %%               , aebytecode
+              %% , "_build/default/lib/aefate/ebin"
+              %% , "node/apps/aecontract"
+              %% , "node/apps/aecore"
+              %% , "node/apps/aetx"
+              ]
+             }
            ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,11 @@
         {lager, {git, "https://github.com/erlang-lager/lager.git",
                  {ref, "fae5339"}}},
         {sha3, {git, "https://github.com/aeternity/erlang-sha3",
-                {ref, "b5f27a2"}}}
+                {ref, "b5f27a2"}}},
+        {ecrecover, {git, "https://github.com/aeternity/ecrecover.git",
+                    {ref, "ce4175e"}}},
+        {emcl, {git, "https://github.com/aeternity/emcl.git",
+               {ref, "e988f69"}}},
        ]}.
 
 {overrides,

--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
         {ecrecover, {git, "https://github.com/aeternity/ecrecover.git",
                     {ref, "ce4175e"}}},
         {emcl, {git, "https://github.com/aeternity/emcl.git",
-               {ref, "e988f69"}}},
+               {ref, "e988f69"}}}
        ]}.
 
 {overrides,

--- a/rebar.config
+++ b/rebar.config
@@ -71,5 +71,9 @@
               %% , "node/apps/aecore"
               %% , "node/apps/aetx"
               ]
+             },
+             {add_pathsa,
+              [ "_build/default/lib/aefate/ebin"
+              ]
              }
            ]}.

--- a/src/aere_debugger.erl
+++ b/src/aere_debugger.erl
@@ -57,9 +57,10 @@ delete_breakpoint(State, File, Line) ->
     aere_repl_state:set_breakpoints(NewBPs, State).
 
 
--spec resume_eval(ReplState, ResumeKind) -> EngineState | no_return()
+-spec resume_eval(ReplState, ResumeKind) -> {Result, ReplState} | no_return()
     when ReplState   :: aere_repl_state:state(),
-         EngineState :: aefa_engine_state:state(),
+         Result      :: {msg, aere_theme:renderable()}
+                      | aere_fate:eval_debug_result(),
          ResumeKind  :: continue | stepin | stepout | stepover.
 
 resume_eval(RS, Kind) ->

--- a/src/aere_debugger.erl
+++ b/src/aere_debugger.erl
@@ -10,6 +10,12 @@
         , stacktrace/1
         ]).
 
+-type source_location() ::
+        #{ file := string()
+         , line := non_neg_integer()
+         }.
+
+-export_type([source_location/0]).
 
 -spec add_breakpoint(ReplState, FileName, Line) -> ReplState
     when ReplState :: aere_repl_state:state(),
@@ -99,9 +105,9 @@ lookup_variable(RS, VarName) ->
     end.
 
 
-- spec get_variables(ReplState) -> Renderable
+- spec get_variables(ReplState) -> Vars
     when ReplState  :: aere_repl_state:state(),
-         Renderable :: aere_theme:renderable().
+         Vars :: list({string(), string()}).
 
 get_variables(RS) ->
     ES = breakpoint_engine_state(RS),
@@ -117,9 +123,7 @@ get_variables(RS) ->
 
 -spec source_location(ReplState) -> Location | no_return()
     when ReplState :: aere_repl_state:state(),
-         Location  :: #{ file := string()
-                       , line := non_neg_integer()
-                       }.
+         Location  :: source_location().
 
 source_location(RS) ->
     ES = breakpoint_engine_state(RS),

--- a/src/aere_debugger.erl
+++ b/src/aere_debugger.erl
@@ -61,7 +61,7 @@ resume_eval(RS, Kind) ->
         {abort, _} ->
             Chain = aere_repl_state:chain_api(RS),
             NewRS = aere_repl_state:set_blockchain_state({ready, Chain}, RS),
-            {aere_msg:contract_exec_ended(), NewRS};
+            {{msg, aere_msg:contract_exec_ended()}, NewRS};
         _ ->
             ES0 = breakpoint_engine_state(RS),
             ES1 = resume(ES0, Kind),

--- a/src/aere_gen_server.erl
+++ b/src/aere_gen_server.erl
@@ -586,6 +586,6 @@ server_error(State, Err, Stacktrace) ->
 -spec prompt_str(BlockchainState) -> string()
     when BlockchainState :: ready | breakpoint | abort.
 
-prompt_str(ready)      -> "AESO";
-prompt_str(breakpoint) -> "AESO(DBG)";
-prompt_str(abort)      -> "AESO(ABORT)".
+prompt_str(ready)      -> <<"AESO">>;
+prompt_str(breakpoint) -> <<"AESO(DBG)">>;
+prompt_str(abort)      -> <<"AESO(ABORT)">>.

--- a/src/aere_gen_server.erl
+++ b/src/aere_gen_server.erl
@@ -141,7 +141,6 @@ init(Args) ->
     Opts1 = Opts#{init_args => Args},
     {ok, aere_repl_state:init_state(Opts1)}.
 
-
 handle_call(quit, _From, State) ->
     {stop, normal, finish, State};
 

--- a/src/aere_gen_server.erl
+++ b/src/aere_gen_server.erl
@@ -526,10 +526,11 @@ server_error(State, Err) ->
     throw({reply, {error, Msg}, State}).
 
 
--spec server_error(ReplState, Error, erlang:stacktrace()) -> {reply, {error, Msg}, ReplState}
+-spec server_error(ReplState, Error, erlang:stacktrace()) ->
+          {reply, {error, Msg}, ReplState}
     when ReplState :: aere_repl_state:state(),
          Error     :: term(),
-         Msg       :: aere_theme:renderable().
+         Msg       :: term().
 
 server_error(State, Err, Stacktrace) ->
     Msg = ?RENDER(

--- a/src/aere_gen_server.erl
+++ b/src/aere_gen_server.erl
@@ -583,7 +583,7 @@ server_error(State, Err, Stacktrace) ->
     throw({reply, {error, Msg}, State}).
 
 
--spec prompt_str(BlockchainState) -> string()
+-spec prompt_str(BlockchainState) -> binary()
     when BlockchainState :: ready | breakpoint | abort.
 
 prompt_str(ready)      -> <<"AESO">>;

--- a/src/aere_macros.hrl
+++ b/src/aere_macros.hrl
@@ -10,12 +10,8 @@
 -define(DEFAULT_CONTRACT_STATE_T, {tuple_t, aere_mock:ann(), []}).
 -define(DEFAULT_CONTRACT_STATE, {?DEFAULT_CONTRACT_STATE_T, {tuple, {}}}).
 
--define(LAZY(C), fun() -> C end).
 -define(IF(C, T, E),
         case C of
             true -> T;
             false -> E
         end).
-
--define(REPL_STATE, rs).
--define(IS_REPL_STATE(T), element(1, T) =:= ?REPL_STATE).

--- a/src/aere_macros.hrl
+++ b/src/aere_macros.hrl
@@ -16,3 +16,6 @@
             true -> T;
             false -> E
         end).
+
+-define(REPL_STATE, rs).
+-define(IS_REPL_STATE(T), element(1, T) =:= ?REPL_STATE).

--- a/src/aere_msg.erl
+++ b/src/aere_msg.erl
@@ -341,11 +341,14 @@ help(What) ->
             help()
     end.
 
+-spec type(aeso_syntax:type()) -> msg().
 type(Type) ->
     TypeStr = aeso_ast_infer_types:pp_type("", Type),
     TypeStrClean = re:replace(TypeStr, ?TYPE_CONTAINER_RE, "", [global, {return, list}]),
     aere_msg:output(TypeStrClean).
 
+-spec eval(Eval, aere_repl_state:options()) -> msg() when
+      Eval :: no_output | {msg, msg()} | aere_fate:eval_debug_result().
 eval(no_output, _) ->
     [];
 eval({msg, Msg}, _) ->
@@ -368,7 +371,7 @@ eval(break, _Opts) ->
 eval({revert, #{err_msg := ErrMsg, stacktrace := Stacktrace}}, _Opts) ->
     abort(ErrMsg, Stacktrace).
 
-
+-spec lookup(string(), list(term())) -> msg().
 lookup(What, Data) ->
     case What of
         "vars"        -> list_vars(Data);
@@ -380,10 +383,12 @@ lookup(What, Data) ->
         "breakpoints" -> list_breakpoints(Data)
     end.
 
+-spec fate(term()) -> msg().
 fate(Fate) ->
     FateStr = lists:flatten(aeb_fate_asm:pp(Fate)),
     aere_msg:output(FateStr).
 
+-spec location(string(), non_neg_integer(), aere_repl_state:state()) -> msg().
 location(FileName, CurrentLine, RS) ->
     #{ loc_backwards := LocBackwards
      , loc_forwards := LocForwards
@@ -407,6 +412,7 @@ location(FileName, CurrentLine, RS) ->
     NewLines = [FormatLine(Idx, Line) || {Idx, Line} <- SelectLines],
     aere_msg:output(lists:join("\n", NewLines)).
 
+-spec debug_vars(list({string(), string()})) -> msg().
 debug_vars(Vars) ->
     Dump = [io_lib:format("~s:\t~s", [K, V]) || {K, V} <- Vars],
 

--- a/src/aere_msg.erl
+++ b/src/aere_msg.erl
@@ -359,7 +359,12 @@ eval({ok, #{result := Res, type := Type, used_gas := UsedGas}}, Opts) ->
        print_type   := PrintType
      } = Opts,
     TypeStr = aeso_ast_infer_types:pp_type("", Type),
-    PrintRes = PrintUnit orelse Res =/= {tuple, {}},
+    PrintRes =
+        case Type of
+            {id, _, "unit"} -> PrintUnit;
+            {tuple_t, _, []} -> PrintUnit;
+            _ -> true
+        end,
 
     [ [aere_theme:output(Res) || PrintRes]
     , [aere_theme:info(" : " ++ TypeStr) || PrintRes andalso PrintType]

--- a/src/aere_msg.erl
+++ b/src/aere_msg.erl
@@ -54,6 +54,7 @@
    , help/0, help/1
    , option_usage/1
    , bye/0
+   , debug_vars/1
    ]).
 
 -type msg() :: aere_theme:renderable().
@@ -405,3 +406,8 @@ location(FileName, CurrentLine, RS) ->
     FormatLine    = fun(N, Ln) -> [LineSign(N), " ", FormatLineNum(N), " ", Ln] end,
     NewLines = [FormatLine(Idx, Line) || {Idx, Line} <- SelectLines],
     aere_msg:output(lists:join("\n", NewLines)).
+
+debug_vars(Vars) ->
+    Dump = [io_lib:format("~s:\t~s", [K, V]) || {K, V} <- Vars],
+
+    output(lists:join("\n", Dump)).

--- a/src/aere_options.erl
+++ b/src/aere_options.erl
@@ -8,6 +8,9 @@ option_parse_rules() ->
     , {call_value, {valid, integer, fun(I) -> I >= 0 end, "non-neg"}}
     , {print_format, {atom, [sophia,json,fate]}}
     , {print_unit, boolean}
+    , {print_type, boolean}
+    , {loc_forwards, {valid, integer, fun(I) -> I >= 0 end, "non-neg"}}
+    , {loc_backwards, {valid, integer, fun(I) -> I >= 0 end, "non-neg"}}
     ].
 
 parse_option(Option, Args) ->

--- a/src/aere_parse.erl
+++ b/src/aere_parse.erl
@@ -227,7 +227,7 @@ parse_args(_, _) ->
     error.
 
 
--spec apply_type(string(), arg_type()) -> arg() | no_return().
+-spec apply_type(string(), arg_type()) -> arg().
 
 apply_type(X, integer) ->
     try
@@ -241,11 +241,7 @@ apply_type(X, atom) ->
     list_to_atom(X);
 
 apply_type(X, string) ->
-    X;
-
-apply_type(_, T) ->
-    throw({parse_error, {unknown_arg_type, T}}).
-
+    X.
 
 -spec words(string()) -> [string()].
 

--- a/src/aere_parse.erl
+++ b/src/aere_parse.erl
@@ -54,7 +54,10 @@ commands() ->
        {[s], [{required, atom}, {some, string}], "SETTING [SETTING_ARGS]",
         [ "Configures REPL environment and behavior. "
         , "Possible usages:"] ++
-            [ "- :set " ++ atom_to_list(Opt) ++ " " ++ aere_options:format_option_scheme(Scheme)
+            [ "- :set " ++
+                  atom_to_list(Opt) ++
+                  " " ++
+                  aere_options:format_option_scheme(Scheme)
               || {Opt, Scheme} <- aere_options:option_parse_rules()
             ]
        }}

--- a/src/aere_parse.erl
+++ b/src/aere_parse.erl
@@ -68,7 +68,7 @@ commands() ->
         , "cannot be adjusted using the put function."
         , "Cleans user variables and functions."]
        }}
-    , {print,
+    , {lookup,
        {[p], [{required, string}], "WHAT",
         [ "Prints REPL state. The argument determines what component is to be printed."
         , "Possible componens:"

--- a/src/aere_parse.erl
+++ b/src/aere_parse.erl
@@ -156,21 +156,21 @@ resolve_command_by_alias(Alias, [Spec = {_, {Aliases, _, _, _}} | Rest]) ->
     end.
 
 
--spec parse(string()) -> parse_result().
+-spec parse(string()) -> {ok, parse_result()} | {error, aere_theme:renerable()}.
 %% @doc
 %% Parse an input string. This function is called on strings entered by the user in the repl
 
 parse(Input) ->
     case string:trim(Input) of
         [] ->
-            skip;
+            {ok, skip};
         ":" ->
-            skip;
+            {ok, skip};
         [$:|CommandAndArgs] ->
             parse_command(CommandAndArgs);
         _ ->
             %% Eval is the default command (i.e. 1 + 1 is just :eval 1 + 1)
-            {eval, Input}
+            {ok, {eval, Input}}
     end.
 
 
@@ -179,8 +179,8 @@ parse_command(CommandAndArgs) ->
     case resolve_command(Cmd) of
         {Command, {_, Scheme, ArgDoc, _}} ->
             try parse_command_scheme(Scheme, ArgStr) of
-                {ok, []}   -> Command;
-                {ok, Args} -> list_to_tuple([Command | Args]);
+                {ok, []}   -> {ok, Command};
+                {ok, Args} -> {ok, list_to_tuple([Command | Args])};
                 error      -> {error, aere_msg:bad_command_args(Command, ArgDoc)}
             catch
                 {parse_error, {bad_integer, _}} ->

--- a/src/aere_repl.erl
+++ b/src/aere_repl.erl
@@ -45,8 +45,8 @@ eval_code(Expr, RS) ->
             {no_output, register_include(Inc, RS)};
         [{letval, _, Pat, Body}] ->
             {no_output, register_letval(Pat, Body, RS)};
-        [{letfun, _, FName, Args, _, Body}] ->
-            {no_output, register_letfun(FName, Args, Body, RS)};
+        %% [{letfun, _, FName, Args, _, Body}] ->
+        %%     {no_output, register_letfun(FName, Args, Body, RS)};
         [{type_def, _, Name, Args, Body}] ->
             {no_output, register_typedef(Name, Args, Body, RS)};
         _ -> error(too_much_stuff) %% FIXME
@@ -212,26 +212,26 @@ register_letval(Pat, Expr, S0) ->
 
 %%%------------------
 
--spec register_letfun(aeso_syntax:id(), [aeso_syntax:pat()], [aeso_syntax:guarded_expr()], repl_state())
-                     -> command_res().
-register_letfun(Id = {id, _, Name}, Args, Body, S0) ->
-    Ast = aere_mock:letfun_contract(Id, Args, Body, S0),
-    {TEnv, TypedAst} = aere_sophia:typecheck(Ast, [allow_higher_order_entrypoints]),
-    ByteCode = aere_sophia:compile_contract(TypedAst),
+%% -spec register_letfun(aeso_syntax:id(), [aeso_syntax:pat()], [aeso_syntax:guarded_expr()], repl_state())
+%%                      -> command_res().
+%% register_letfun(Id = {id, _, Name}, Args, Body, S0) ->
+%%     Ast = aere_mock:letfun_contract(Id, Args, Body, S0),
+%%     {TEnv, TypedAst} = aere_sophia:typecheck(Ast, [allow_higher_order_entrypoints]),
+%%     ByteCode = aere_sophia:compile_contract(TypedAst),
 
-    Type = aere_sophia:type_of_user_input(TEnv),
+%%     Type = aere_sophia:type_of_user_input(TEnv),
 
-    NameMap = build_fresh_name_map(ByteCode),
+%%     NameMap = build_fresh_name_map(ByteCode),
 
-    Funs1 = generated_functions(ByteCode, NameMap),
+%%     Funs1 = generated_functions(ByteCode, NameMap),
 
-    FunNewName = maps:get(aeb_fate_code:symbol_identifier(binary:list_to_bin(Name)), NameMap),
-    FunVal = {tuple, {FunNewName, {tuple, {}}}}, %% TODO this is broken
+%%     FunNewName = maps:get(aeb_fate_code:symbol_identifier(binary:list_to_bin(Name)), NameMap),
+%%     FunVal = {tuple, {FunNewName, {tuple, {}}}}, %% TODO this is broken
 
-    S1 = register_vars([{Name, Type, FunVal}], S0),
-    S2 = aere_repl_state:set_funs(maps:merge(aere_repl_state:funs(S1), Funs1), S1),
+%%     S1 = register_vars([{Name, Type, FunVal}], S0),
+%%     S2 = aere_repl_state:set_funs(maps:merge(aere_repl_state:funs(S1), Funs1), S1),
 
-    {aere_theme:error("Warning: defining functions in REPL is WIP and may be unstable."), S2}.
+%%     {aere_theme:error("Warning: defining functions in REPL is WIP and may be unstable."), S2}.
 
 register_vars(NewVars, S) ->
     OldVars = aere_repl_state:vars(S),
@@ -325,7 +325,7 @@ disassemble(What, S0) ->
             {TEnv, TAst} = aere_sophia:typecheck(Contract, [allow_higher_order_entrypoints]),
             S1_0 = aere_repl_state:set_type_env(TEnv, S1),
             MockByteCode = aere_sophia:compile_contract(TAst),
-            #{value := {tuple, {FName, _}}} = aere_fate:run_contract(MockByteCode, S1_0),
+            {#{value := {tuple, {FName, _}}}, _} = aere_fate:run_contract(MockByteCode, S1_0),
             aere_fate:extract_fun_from_bytecode(MockByteCode, FName);
         {local, _Name} ->
             error(not_supported);

--- a/src/aere_repl.erl
+++ b/src/aere_repl.erl
@@ -46,11 +46,10 @@ eval_code(Expr, RS) ->
             {ok, register_include(Inc, RS)};
         [{letval, _, Pat, Body}] ->
             {ok, register_letval(Pat, Body, RS)};
-        %% [{letfun, _, FName, Args, _, Body}] ->
-        %%     {ok, register_letfun(FName, Args, Body, RS)};
         [{type_def, _, Name, Args, Body}] ->
             {ok, register_typedef(Name, Args, Body, RS)};
-        _ -> error(too_much_stuff) %% FIXME
+        _ ->
+            throw({repl_error, aere_msg:unsupported_eval(Parse)})
     end.
 
 -spec set_state([aeso_syntax:stmt()], repl_state())
@@ -210,29 +209,6 @@ register_letval(Pat, Expr, S0) ->
     S3 = aere_repl_state:set_funs(maps:merge(OldFuns, NewFuns), S2),
 
     S3.
-
-%%%------------------
-
-%% -spec register_letfun(aeso_syntax:id(), [aeso_syntax:pat()], [aeso_syntax:guarded_expr()], repl_state())
-%%                      -> command_res().
-%% register_letfun(Id = {id, _, Name}, Args, Body, S0) ->
-%%     Ast = aere_mock:letfun_contract(Id, Args, Body, S0),
-%%     {TEnv, TypedAst} = aere_sophia:typecheck(Ast, [allow_higher_order_entrypoints]),
-%%     ByteCode = aere_sophia:compile_contract(TypedAst),
-
-%%     Type = aere_sophia:type_of_user_input(TEnv),
-
-%%     NameMap = build_fresh_name_map(ByteCode),
-
-%%     Funs1 = generated_functions(ByteCode, NameMap),
-
-%%     FunNewName = maps:get(aeb_fate_code:symbol_identifier(binary:list_to_bin(Name)), NameMap),
-%%     FunVal = {tuple, {FunNewName, {tuple, {}}}}, %% TODO this is broken
-
-%%     S1 = register_vars([{Name, Type, FunVal}], S0),
-%%     S2 = aere_repl_state:set_funs(maps:merge(aere_repl_state:funs(S1), Funs1), S1),
-
-%%     {aere_theme:error("Warning: defining functions in REPL is WIP and may be unstable."), S2}.
 
 register_vars(NewVars, S) ->
     OldVars = aere_repl_state:vars(S),

--- a/src/aere_repl.erl
+++ b/src/aere_repl.erl
@@ -29,6 +29,7 @@
 -type command_res() :: finish | repl_state() | no_return().
 -type command_res(T) :: {T, repl_state()} | command_res().
 
+
 infer_type(Expr, RS) ->
     Stmts = aere_sophia:parse_body(Expr),
     Contract = aere_mock:eval_contract(Stmts, RS),
@@ -42,13 +43,13 @@ eval_code(Expr, RS) ->
         {body, Body} ->
             eval_expr(Body, RS);
         [{include, _, {string, _, Inc}}] ->
-            {no_output, register_include(Inc, RS)};
+            {ok, register_include(Inc, RS)};
         [{letval, _, Pat, Body}] ->
-            {no_output, register_letval(Pat, Body, RS)};
+            {ok, register_letval(Pat, Body, RS)};
         %% [{letfun, _, FName, Args, _, Body}] ->
-        %%     {no_output, register_letfun(FName, Args, Body, RS)};
+        %%     {ok, register_letfun(FName, Args, Body, RS)};
         [{type_def, _, Name, Args, Body}] ->
-            {no_output, register_typedef(Name, Args, Body, RS)};
+            {ok, register_typedef(Name, Args, Body, RS)};
         _ -> error(too_much_stuff) %% FIXME
     end.
 

--- a/src/aere_repl_state.erl
+++ b/src/aere_repl_state.erl
@@ -33,7 +33,7 @@
                      | {abort, aefa_engine_state:state()}.
 -type filesystem() :: local | {cached, #{string() => binary()}}.
 
--record(?REPL_STATE,
+-record(rs,
         { blockchain_state       :: chain_state()
         , repl_account           :: binary()
         , options                :: repl_options()

--- a/src/aere_repl_state.erl
+++ b/src/aere_repl_state.erl
@@ -127,8 +127,7 @@ init_state() ->
 -spec init_state(repl_options()) -> state().
 init_state(Opts) ->
     Trees0 = aec_trees:new(),
-    {_, Trees} = aere_chain:new_account(100000000000000000000000000000, Trees0),
-    PK = <<0:256>>,
+    {PK, Trees} = aere_chain:new_account(100000000000000000000000000000, Trees0),
     ChainState = aefa_chain_api:new(
                    #{ gas_price => 1,
                       fee       => 0,

--- a/src/aere_repl_state.erl
+++ b/src/aere_repl_state.erl
@@ -9,18 +9,30 @@
 -type print_format() :: sophia | fate | json.
 -type return_mode() :: value | format | render.
 -type repl_options() ::
-        #{ theme       := aere_theme:theme()
-         , display_gas  := boolean()
-         , call_gas     := pos_integer()
-         , call_value   := non_neg_integer()
-         , print_format := print_format()
-         , return_mode  := return_mode()
-         , print_unit   := boolean()
-         , print_type   := boolean()
-         , loc_backwards := non_neg_integer()
-         , loc_forwards  := non_neg_integer()
-         , locked_opts  => [atom()]
-         , init_args    => [any()]
+        #{ % Theme used for rendering
+           theme        := aere_theme:theme()
+         , % Whether to measure gas usage on each eval
+           display_gas  := boolean()
+         , % How much gas to use for each eval
+           call_gas     := pos_integer()
+         , % What should `Call.value` return
+           call_value   := non_neg_integer()
+         , % How to display eval results and types
+           print_format := print_format()
+         , % Whether to render results and how, or return Erlang values
+           return_mode  := return_mode()
+         , % Whether to print () if the result is a 0-tuple
+           print_unit   := boolean()
+         , % Whether to attach type to each eval result
+           print_type   := boolean()
+         , % When looking up code location, how many lines backwards to show
+           loc_backwards := non_neg_integer()
+         , % When looking up code location, how many lines forwards to show
+           loc_forwards  := non_neg_integer()
+         , % Which options should be prevented from being changed
+           locked_opts  => [atom()]
+         , % Arguments used to initialize the REPL. Used in restarts.
+           init_args    => [any()]
          }.
 -type breakpoints() :: [{string(), integer()}].
 -type function_symbols() :: #{binary() => binary()}.
@@ -118,6 +130,7 @@ init_options() ->
      , loc_backwards => 5
      , loc_forwards  => 5
      , locked_opts   => []
+     , init_args     => []
     }.
 
 -spec init_state() -> state().

--- a/src/aere_repl_state.erl
+++ b/src/aere_repl_state.erl
@@ -20,8 +20,8 @@
          , loc_backwards := non_neg_integer()
          , loc_forwards  := non_neg_integer()
          , locked_opts  => [atom()]
+         , init_args    => [any()]
          }.
--type command_res() :: finish | {aere_theme:renderable(), state()} | state() | no_return().
 -type breakpoints() :: [{string(), integer()}].
 -type function_symbols() :: #{binary() => binary()}.
 -type var() :: {string(), aeso_syntax:type(), term()}.
@@ -54,7 +54,9 @@
 
 -opaque state() :: #rs{}.
 
--export_type([state/0, type_scope/0, type_def/0, repl_options/0, command_res/0, function_symbols/0, breakpoints/0]).
+-export_type(
+   [ state/0, type_scope/0, type_def/0, repl_options/0
+   , function_symbols/0, breakpoints/0]).
 
 -export([ init_state/0, init_state/1
         , init_options/0
@@ -286,7 +288,7 @@ chain_api(#rs{blockchain_state = {abort, ES}}) ->
 bump_nonce(S = #rs{query_nonce = N}) ->
     S#rs{query_nonce = N + 1}.
 
--spec update_cached_fs(#{string() => binary()}, state()) -> state().
+-spec update_cached_fs(#{string() => binary()}, state()) -> error | {ok, state()}.
 update_cached_fs(_, #rs{filesystem = local}) ->
     error;
 update_cached_fs(Fs, S) when is_map(Fs) ->

--- a/src/aere_sophia.erl
+++ b/src/aere_sophia.erl
@@ -16,6 +16,10 @@
 
 -include("aere_macros.hrl").
 
+-type parsing_result() :: [aeso_syntax:decl()] | {body, [aeso_syntax:stmt()]}.
+
+-export_type([parsing_result/0]).
+
 optimizations_off() ->
     [ {optimize_inliner, false},
       {optimize_inline_local_functions, false},
@@ -70,7 +74,7 @@ type_of_user_input(TEnv0) ->
     Type.
 
 -define(with_error_handle(X), try X catch {error, Errs} -> process_err(Errs) end).
--spec parse_top(string()) -> [aeso_syntax:decl()] | {body, [aeso_syntax:stmt()]} | none().
+-spec parse_top(string()) -> parsing_result() | none().
 parse_top(I) ->
     parse_top(I, []).
 -spec parse_top(string(), [term()]) -> [aeso_syntax:decl()] | {body, [aeso_syntax:stmt()]} | none().
@@ -93,6 +97,7 @@ parse_top(I, Opts) ->
                       end)
              ]),
     ?with_error_handle(aeso_parser:run_parser(Top, I, Opts)).
+
 parse_body(I) ->
     ?with_error_handle(
        case aeso_parser:run_parser(aeso_parser:body(), I) of

--- a/src/aere_supervisor.erl
+++ b/src/aere_supervisor.erl
@@ -2,21 +2,24 @@
 
 -behaviour(supervisor).
 
--export([start_link/0]).
+-export([start_link/0, start_link/1, terminate/1]).
 
 -export([init/1]).
 
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
-init(_Args) ->
+start_link(ReplArgs) ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, ReplArgs).
+
+init(ReplArgs) ->
     Flags = #{strategy => one_for_one,
               intensity => 5,
               period => 3
             },
     ChildSpecs =
         [ #{id => aerepl,
-            start => {aere_gen_server, start_link, [[]]},
+            start => {aere_gen_server, start_link, [ReplArgs]},
             restart => permanent,
             significant => false,
             shutdown => brutal_kill,
@@ -25,3 +28,8 @@ init(_Args) ->
           }
         ],
     {ok, {Flags, ChildSpecs}}.
+
+terminate(Pid) ->
+    supervisor:terminate_child(Pid, aerepl),
+    supervisor:delete_child(Pid, aerepl),
+    ok.

--- a/src/aere_theme.erl
+++ b/src/aere_theme.erl
@@ -141,15 +141,20 @@ file(Text) -> make_themed(file, Text).
 info(Text) -> make_themed(info, Text).
 
 %% Like render/2, but with the empty theme
--spec render(renderable()) -> string().
+-spec render(renderable()) -> binary().
 render(ThemedTxts) ->
     render(empty_theme(), ThemedTxts).
 
-%% Render a given renderable as an ANSI escaped string in the provided theme
--spec render(theme(), renderable()) -> string().
-render(Theme, ThemedTxt = {themed, _, _}) ->
-    render(Theme, [ThemedTxt]);
-render(Theme, ThemedTxts) when is_list(ThemedTxts) ->
+%% Render a given renderable as an ANSI escaped byte string in the provided theme
+-spec render(theme(), renderable()) -> binary().
+render(Theme, ThemedTxts) ->
+    Str = render_str(Theme, ThemedTxts),
+    list_to_binary(Str).
+
+-spec render_str(theme(), renderable()) -> string().
+render_str(Theme, ThemedTxt = {themed, _, _}) ->
+    render_str(Theme, [ThemedTxt]);
+render_str(Theme, ThemedTxts) when is_list(ThemedTxts) ->
     AnsiStr = lists:flatten(lists:map(fun(T) -> apply_theme(Theme, T) end, lists:flatten(ThemedTxts))),
     string:trim(AnsiStr, trailing, unicode_util:whitespace()).
 

--- a/src/aere_theme.erl
+++ b/src/aere_theme.erl
@@ -46,10 +46,11 @@
 ansi_color_no(Color) ->
     case Color of
         black     -> "0";
-        red       -> case get(wololo) of  %% This is here to make people confused
-                         wololo -> "4";
-                         _      -> "1"
-                     end;
+        red       ->
+            case get(wololo) of  %% This is here to make people confused
+                wololo -> ansi_color_no(blue);
+                _      -> "1"
+            end;
         green     -> "2";
         yellow    -> "3";
         blue      -> "4";

--- a/src/aere_version.erl
+++ b/src/aere_version.erl
@@ -10,6 +10,8 @@
         , node_version/0
         ]).
 
+-export([version_info/0]).
+
 -include("../node/apps/aecontract/src/aect_sophia.hrl").
 -include("../node/apps/aecontract/include/aecontract.hrl").
 -include("../node/apps/aecontract/include/hard_forks.hrl").
@@ -44,3 +46,14 @@ node_version() ->
     app_version(aecore).
 compiler_version() ->
     app_version(aesophia).
+
+version_info() ->
+    #{ protocol_version => aere_version:protocol_version()
+     , abi_version => aere_version:abi_version()
+     , sophia_version => aere_version:sophia_version()
+     , contract_version => aere_version:contract_version()
+     , vm_version => aere_version:vm_version()
+     , repl_version => aere_version:repl_version()
+     , compiler_version => aere_version:compiler_version()
+     , node_version => aere_version:node_version()
+     }.

--- a/src/aerepl.app.src
+++ b/src/aerepl.app.src
@@ -4,9 +4,11 @@
   {mod, {aerepl, []}},
   {registered, []},
   {applications,
-   [kernel,
-    stdlib,
-    aesophia
+   [ kernel
+   , stdlib
+   , aesophia
+   , aebytecode
+   , aeserialization
    ]},
   {env,[]},
   {modules, []},

--- a/src/aerepl.app.src
+++ b/src/aerepl.app.src
@@ -1,6 +1,6 @@
 {application, aerepl,
  [{description, "Read-Eval-Print Loop for Sophia"},
-  {vsn, "3.1.1"},
+  {vsn, "3.2.0"},
   {mod, {aerepl, []}},
   {registered, []},
   {applications,


### PR DESCRIPTION
This PR makes a step towards more structured replies of the REPL by adding more separation between visuals and returned data. The generice server now renders messages only optionally based on the configuration.